### PR TITLE
Allow to set custom user data

### DIFF
--- a/lib/login_state.js
+++ b/lib/login_state.js
@@ -2,6 +2,14 @@ if(!LoginState) {
   LoginState = {};
 }
 
+LoginState.getUserData = function(user) {
+  return {
+    username: user.username,
+    userId: user._id,
+    email: user.emails && user.emails[0] && user.emails[0].address
+  };
+}
+
 LoginState.init = function(domain, cookieName, maxage) {
   if(typeof domain == "undefined") {
     throw new Error("domain is required for login-state");
@@ -13,13 +21,10 @@ LoginState.init = function(domain, cookieName, maxage) {
   Tracker.autorun(function() {
     var user = Meteor.user && Meteor.user();
     if(user) {
-      var data = {
+      var data = _.extend({
         timestamp: Date.now(),
-        username: user.username,
-        userId: user._id,
-        email: user.emails && user.emails[0] && user.emails[0].address,
         url: window.location.origin
-      };
+      }, LoginState.getUserData(user));
 
       Cookie.set(cookieName, JSON.stringify(data), {
         path: "/",

--- a/package.js
+++ b/package.js
@@ -22,7 +22,10 @@ Package.on_test(function(api) {
 });
 
 function configurePackage(api) {
-  api.use('chuangbo:cookie@1.1.0');
+  api.use([
+    'underscore',
+    'chuangbo:cookie@1.1.0'
+  ]);
   api.addFiles([
     'client/login_state.js',
     'lib/login_state.js',


### PR DESCRIPTION
I needed to store some additional fields in the cookie and i'm not using usernames.

This adds a function that can be overridden before Meteor.startup.

``` js
LoginState.getUserData = function(user) {
  return {
    username: user.username,
    userId: user._id,
    email: user.emails && user.emails[0] && user.emails[0].address
  };
}
```
